### PR TITLE
filterComponent prop added in docs

### DIFF
--- a/src/pages/docs/all-props/columns.md
+++ b/src/pages/docs/all-props/columns.md
@@ -16,6 +16,7 @@
 | field                   | string                                       |           | Field name of data row                                                                                        |
 | filtering               | boolean                                      | true      | Flag to activate or disable filtering feature of column                                                       |
 | filterCellStyle         | object                                       |           | Filter cell style                                                                                             |
+| filterComponent         | ReactElement                                 |           | Custom component for filtering                                                                                |
 | filterPlaceholder       | string                                       |           | Filter textbox placeholder                                                                                    |
 | grouping                | boolean                                      | true      | Flag to activate or disable grouping feature of column                                                        | 
 | headerStyle             | object                                       |           | Header cell style                                                                                             |


### PR DESCRIPTION
Fix:
One prop was missing in docs of filterComponent, which allows you to render custom components for filtering. I have added the prop in the documentation. Please look into it and merge.

https://github.com/mbrn/material-table.com/issues/36