### PR TITLE
removed table breaking whitespace from columns.md

### DIFF
--- a/src/pages/docs/all-props/columns.md
+++ b/src/pages/docs/all-props/columns.md
@@ -9,7 +9,6 @@
 | defaultGroupOrder       | number                                       |           | Default grouped column by order                                                                               |
 | defaultGroupSort        | 'asc' or 'desc'                              | 'asc'     | Default grouped sort direction                                                                                |
 | defaultSort             | 'asc' or 'desc'                              |           | Sorting direction: 'asc', 'desc'    
-
 | dateSetting              | { locale: string}                             |           | The locale used to format the displayed date/time                                                                              |
 | disableClick            | boolean                                      | false     | Disable the 'onRowClick' event for this cell                                                                  |
 | editable                | 'always' 'never' 'onUpdate' 'onAdd'          | 'always'  | Editable custom component                                                                                     |


### PR DESCRIPTION
a new line was breaking the 'columns' table in the docs.

Wasn't sure if I was supposed to run a build, so I didn't.