### PR TITLE
Correct name of column that is read-only.

### DIFF
--- a/src/pages/docs/features/editable/index.mdx
+++ b/src/pages/docs/features/editable/index.mdx
@@ -107,7 +107,7 @@ To make table cells editable, you should set `cellEditable` prop that has `onCel
     code={require('!!raw-loader!./disable-field-editable.js').default}
     scope={{ MaterialTable }}
     title="Disable Field Editable Example"
-    description="A simple editable implementation with a reaonly name column"
+    description="A simple editable implementation with a readonly surname column"
 />
 
 <LiveCode


### PR DESCRIPTION
Guidance suggests it's the `name` field that is read only, but it's actually the `surname` field.

Plus, typo in `readonly`